### PR TITLE
Updates to work with LWJGL 3.2.3 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 bin/
 build/
 target/
+.gradle/

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,73 @@
-apply plugin: "java"
+plugins {
+    id 'application'
+}
 
-project.ext.lwjglVersion = "3.0.0a"
+wrapper {
+    gradleVersion = '6.7.1'
+    distributionType = Wrapper.DistributionType.ALL
+}
+
+group = 'lwjgl3-tests'
+version = '0.0.1-SNAPSHOT'
+
+ext {
+    lwjglVersion = '3.2.3'
+
+    //LWJGL modules for compile classpath
+
+    //level: getting started
+    //lwjglModules = ['lwjgl', 'lwjgl-assimp', 'lwjgl-bgfx', 'lwjgl-glfw', 'lwjgl-nanovg', 'lwjgl-nuklear',
+    //                'lwjgl-openal', 'lwjgl-opengl', 'lwjgl-par', 'lwjgl-stb', 'lwjgl-vulkan']
+
+    //level: minimal OpenGL
+    lwjglModules = ['lwjgl', 'lwjgl-assimp', 'lwjgl-glfw', 'lwjgl-openal', 'lwjgl-opengl', 'lwjgl-stb']
+
+    //level: minimal OpenGL ES
+    //lwjglModules = ['lwjgl', 'lwjgl-assimp', 'lwjgl-egl', 'lwjgl-glfw', 'lwjgl-openal', 'lwjgl-opengles', 'lwjgl-stb']
+
+    //level: minimal Vulkan
+    //lwjglModules = ['lwjgl', 'lwjgl-assimp', 'lwjgl-glfw', 'lwjgl-openal', 'lwjgl-stb', 'lwjgl-vulkan']
+
+    //LWJGL modules with native libraries for runtime classpath
+    lwjglNativeModules = lwjglModules - ['lwjgl-egl'] //lwjgl-egl has no native libraries
+
+    //classifiers for supported OS'es with native libraries
+    //osNativeClassifiers = ['natives-windows', 'natives-windows-x86', 'natives-macos',
+    //                       'natives-linux', 'natives-linux-arm64', 'natives-linux-arm32'] //all supported OS'es
+    osNativeClassifiers = ['natives-windows', 'natives-macos', 'natives-linux'] //64bit OS'es on Intel platform
+}
 
 repositories {
     mavenCentral()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.4'
+    mavenLocal()
 }
 
 dependencies {
-	compile "org.lwjgl:lwjgl:${lwjglVersion}"
-	compile "org.lwjgl:lwjgl-platform:${lwjglVersion}:natives-windows"
-	compile "org.lwjgl:lwjgl-platform:${lwjglVersion}:natives-linux"
-	compile "org.lwjgl:lwjgl-platform:${lwjglVersion}:natives-osx"
+    //get recommended dependency versions from the LWJGL BOM
+	implementation platform("org.lwjgl:lwjgl-bom:$lwjglVersion")
+
+    //add LWJGL modules to the compile classpath
+    lwjglModules.each {
+        implementation "org.lwjgl:$it"
+    }
+
+    //add LWJGL native libraries of all supported OS'es to the runtime classpath
+    lwjglNativeModules.each { lwjglModule ->
+        osNativeClassifiers.each { osNativeClassifier ->
+            if ('lwjgl-vulkan' == lwjglModule) {
+                //Vulkan module is only implemented with MacOsX natives
+                if ('natives-macos' == osNativeClassifier) {
+                    runtimeOnly "org.lwjgl:$lwjglModule::$osNativeClassifier"
+                }
+            } else {
+                runtimeOnly "org.lwjgl:$lwjglModule::$osNativeClassifier"
+            }
+        }
+    }
 }
+
+application {
+    mainClass = 'Lwjgl3Test'
+}
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -23,31 +23,139 @@
 	</repositories>
 	
 	<properties>
-		<lwjgl.version>3.0.0a</lwjgl.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<lwjgl.version>3.2.3</lwjgl.version>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.lwjgl</groupId>
+				<artifactId>lwjgl-bom</artifactId>
+				<version>${lwjgl.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
+		<!-- dependencies for LWJGL app development with minimal OpenGL support,
+			 and for 3 native 64-bit OS'es on Intel platform -->
 		<dependency>
 			<groupId>org.lwjgl</groupId>
 			<artifactId>lwjgl</artifactId>
-			<version>${lwjgl.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.lwjgl</groupId>
-			<artifactId>lwjgl-platform</artifactId>
-			<version>${lwjgl.version}</version>
+			<artifactId>lwjgl-assimp</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-glfw</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-openal</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-opengl</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-stb</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl</artifactId>
 			<classifier>natives-windows</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.lwjgl</groupId>
-			<artifactId>lwjgl-platform</artifactId>
-			<version>${lwjgl.version}</version>
-			<classifier>natives-osx</classifier>
+			<artifactId>lwjgl</artifactId>
+			<classifier>natives-macos</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.lwjgl</groupId>
-			<artifactId>lwjgl-platform</artifactId>
-			<version>${lwjgl.version}</version>
+			<artifactId>lwjgl</artifactId>
+			<classifier>natives-linux</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-assimp</artifactId>
+			<classifier>natives-windows</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-assimp</artifactId>
+			<classifier>natives-macos</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-assimp</artifactId>
+			<classifier>natives-linux</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-glfw</artifactId>
+			<classifier>natives-windows</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-glfw</artifactId>
+			<classifier>natives-macos</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-glfw</artifactId>
+			<classifier>natives-linux</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-openal</artifactId>
+			<classifier>natives-windows</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-openal</artifactId>
+			<classifier>natives-macos</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-openal</artifactId>
+			<classifier>natives-linux</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-opengl</artifactId>
+			<classifier>natives-windows</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-opengl</artifactId>
+			<classifier>natives-macos</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-opengl</artifactId>
+			<classifier>natives-linux</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-stb</artifactId>
+			<classifier>natives-windows</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-stb</artifactId>
+			<classifier>natives-macos</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.lwjgl</groupId>
+			<artifactId>lwjgl-stb</artifactId>
 			<classifier>natives-linux</classifier>
 		</dependency>
 	</dependencies>

--- a/src/main/java/Lwjgl3Test.java
+++ b/src/main/java/Lwjgl3Test.java
@@ -1,13 +1,12 @@
-import org.lwjgl.Sys;
-import org.lwjgl.glfw.*;
-import org.lwjgl.opengl.*;
- 
-import java.nio.ByteBuffer;
- 
-import static org.lwjgl.glfw.Callbacks.*;
 import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.opengl.GL11.*;
-import static org.lwjgl.system.MemoryUtil.*;
+import static org.lwjgl.system.MemoryUtil.NULL;
+
+import org.lwjgl.Version;
+import org.lwjgl.glfw.GLFWErrorCallback;
+import org.lwjgl.glfw.GLFWKeyCallback;
+import org.lwjgl.glfw.GLFWVidMode;
+import org.lwjgl.opengl.GL;
  
 public class Lwjgl3Test {
  
@@ -19,7 +18,7 @@ public class Lwjgl3Test {
     private long window;
  
     public void run() {
-        System.out.println("Hello LWJGL " + Sys.getVersion() + "!");
+        System.out.println("Hello LWJGL " + Version.getVersion() + "!");
  
         try {
             init();
@@ -27,21 +26,21 @@ public class Lwjgl3Test {
  
             // Release window and window callbacks
             glfwDestroyWindow(window);
-            keyCallback.release();
+            keyCallback.free();
         } finally {
             // Terminate GLFW and release the GLFWerrorfun
             glfwTerminate();
-            errorCallback.release();
+            errorCallback.free();
         }
     }
  
     private void init() {
         // Setup an error callback. The default implementation
         // will print the error message in System.err.
-        glfwSetErrorCallback(errorCallback = errorCallbackPrint(System.err));
+        glfwSetErrorCallback(errorCallback = GLFWErrorCallback.createPrint(System.err));
  
         // Initialize GLFW. Most GLFW functions will not work before doing this.
-        if ( glfwInit() != GL11.GL_TRUE )
+        if ( !glfwInit() )
             throw new IllegalStateException("Unable to initialize GLFW");
  
         // Configure our window
@@ -62,17 +61,17 @@ public class Lwjgl3Test {
             @Override
             public void invoke(long window, int key, int scancode, int action, int mods) {
                 if ( key == GLFW_KEY_ESCAPE && action == GLFW_RELEASE )
-                    glfwSetWindowShouldClose(window, GL_TRUE); // We will detect this in our rendering loop
+                    glfwSetWindowShouldClose(window, true); // We will detect this in our rendering loop
             }
         });
  
         // Get the resolution of the primary monitor
-        ByteBuffer vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+        GLFWVidMode vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
         // Center our window
         glfwSetWindowPos(
             window,
-            (GLFWvidmode.width(vidmode) - WIDTH) / 2,
-            (GLFWvidmode.height(vidmode) - HEIGHT) / 2
+            (vidmode.width() - WIDTH) / 2,
+            (vidmode.height() - HEIGHT) / 2
         );
  
         // Make the OpenGL context current
@@ -85,20 +84,20 @@ public class Lwjgl3Test {
     }
  
     private void loop() {
-        // This line is critical for LWJGL's interoperation with GLFW's
+        // This line is critical for LWJGL's inter-operation with GLFW's
         // OpenGL context, or any context that is managed externally.
         // LWJGL detects the context that is current in the current thread,
         // creates the ContextCapabilities instance and makes the OpenGL
         // bindings available for use.
-        GLContext.createFromCurrent();
+        GL.createCapabilities();
  
         // Set the clear color
         glClearColor(1.0f, 0.0f, 0.0f, 0.0f);
  
         // Run the rendering loop until the user has attempted to close
         // the window or has pressed the ESCAPE key.
-        while ( glfwWindowShouldClose(window) == GL_FALSE ) {
-            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // clear the framebuffer
+        while ( !glfwWindowShouldClose(window) ) {
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); // clear the frame buffer
  
             glfwSwapBuffers(window); // swap the color buffers
  
@@ -107,9 +106,8 @@ public class Lwjgl3Test {
             glfwPollEvents();
         }
     }
- 
+
     public static void main(String[] args) {
-    	SharedLibraryLoader.load();
         new Lwjgl3Test().run();
     }
  


### PR DESCRIPTION
- code in Lwjgl3Test.java updated to fix compile errors

- SharedLibraryLoader class is not needed now, as LWJGL now loads the
needed native libraries by itself at runtime from the classpath

- Gradle/Maven build scripts updated to use minimal OpenGL set of LWJGL
modules, for the 3 supported OS natives

- the sample application Lwjgl3Test is fully working, and can be
launched via the Gradle run command:
    gradlew run
or via the Maven run command:
    mvn exec:java -Dexec.mainClass=Lwjgl3Test

- Gradle wrapper updated to version 6.7.1

- Gradle build script can produce a zip distribution, in
build/distributions directory, via the 'gradlew distZip' command, and
the resulting zip file should work in the 3 supported OS'es.